### PR TITLE
Provide metadata for bugtracker

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,8 +17,11 @@ WriteMakefile(
     {
       resources =>
       {
-	repository  => 'http://github.com/rurban/b-keywords',
-	license     => 'http://dev.perl.org/licenses/',
+        repository  => 'http://github.com/rurban/b-keywords',
+        license     => 'http://dev.perl.org/licenses/',
+        bugtracker  => {
+            web    => 'https://github.com/rurban/b-keywords/issues',
+        },
       },
     }
    ) : ()),


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Display.html?id=134337#txn-1931083 suggests
that the maintainer would now prefer bug tickets to be filed at GitHub
Issues page for this library.  If this is the case, then this patch is a
step in that direction.