### PR TITLE
Fixes failing test on macOS, preventing install

### DIFF
--- a/t/11keywords.t
+++ b/t/11keywords.t
@@ -35,7 +35,7 @@ sub kopen {
     # Apple has restructured it's file system, if we're on macOS and the above
     # doesn't exist, we're probably using system perl. try an alternate location
     # via Apple's tools
-    if (($files[0] =~ /darwin/) and (! -e $files[0])) {
+    if ($^O eq "darwin" && $Config{archlibexp} =~ m!^/System/Library/Perl!) {
 	my $p = '';
 	$p = qx/xcrun --show-sdk-path/;
 	chomp $p;

--- a/t/11keywords.t
+++ b/t/11keywords.t
@@ -28,6 +28,12 @@ sub _map_control_char {
 # Test everything in keywords.h is covered.
 {
     my $keywords = File::Spec->catfile( $Config{archlibexp}, 'CORE', 'keywords.h' );
+    if ($keywords =~ /darwin/) {
+        my $p = '';
+        $p = qx/xcrun --show-sdk-path/;
+        chomp $p;
+        $keywords = File::Spec->catdir($p, $keywords);
+    }
     open FH, "< $keywords\0" or die "Can't open $keywords: $!";
     local $/;
     chomp( my @keywords = <FH> =~ /^\#define \s+ KEY_(\S+) /xmsg );

--- a/t/11keywords.t
+++ b/t/11keywords.t
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+# -*- perl -*-
 
+use warnings;
 use strict;
 use Test::More 'no_plan';
 

--- a/t/export.t
+++ b/t/export.t
@@ -1,5 +1,6 @@
-#!/usr/bin/perl -w
+# -*- perl -*-
 
+use warnings;
 use strict;
 use Test::More tests => 7;
 


### PR DESCRIPTION
Test `11keywords.t` fails on recent versions of macOS due to Apple
relocating files. This commit test's for `darwin` and adds the necessary
prefix.

See also @hakonhagland comment in #2.

Closes #2
