### PR TITLE
Add Corinna keywords, new with Perl 5.38.0.

### DIFF
--- a/lib/B/Keywords.pm
+++ b/lib/B/Keywords.pm
@@ -481,6 +481,13 @@ use vars '@Barewords';
       finally
     ) : ()
   ),
+  ($] >= 5.038000 ? qw(
+      ADJUST
+      class
+      field
+      method
+    ) : ()
+  ),
 );
 
 # Extra barewords not in keywords.h (import was never in keywords)


### PR DESCRIPTION
To the best of my knowledge these were NOT in any 5.37.* release.