### PR TITLE
Add bareword __CLASS__ if $] >= 5.039002.

### DIFF
--- a/lib/B/Keywords.pm
+++ b/lib/B/Keywords.pm
@@ -488,6 +488,10 @@ use vars '@Barewords';
      method
     ) : ()
   ),
+  ($] >= 5.039002 ? qw{
+     __CLASS__
+    } : ()
+  ),
 );
 
 # Extra barewords not in keywords.h (import was never in keywords)


### PR DESCRIPTION
The Perl version is based on the contents of perl5392delta.pod.

Passes tests under 5.38.2, 5.39.10, and 5.40.0-RC1. Without this t/11keywords.t fails under 5.40.0-RC1.