### PR TITLE
Avoid warning about possible attempt to escape whitespace

### DIFF
--- a/lib/B/Keywords.pm
+++ b/lib/B/Keywords.pm
@@ -30,8 +30,9 @@ use vars '@Scalars';
     qw( $* $MULTILINE_MATCHING) : ()),
     qw( $. $INPUT_LINE_NUMBER $NR
         $/ $INPUT_RECORD_SEPARATOR $RS
-        $| $OUTPUT_AUTOFLUSH ), '$,', qw( $OUTPUT_FIELD_SEPARATOR $OFS
-        $\ $OUTPUT_RECORD_SEPARATOR $ORS
+        $| $OUTPUT_AUTOFLUSH ), '$,', qw( $OUTPUT_FIELD_SEPARATOR $OFS ),
+        '$\\', qw( $OUTPUT_RECORD_SEPARATOR $ORS ),
+    qw(
         $" $LIST_SEPARATOR
         $; $SUBSCRIPT_SEPARATOR $SUBSEP
     ), '$#', qw( $OFMT


### PR DESCRIPTION
During the Perl 5.43 development cycle, a new warning has been introduced that triggers when code like this is observed:

        qw( \ )